### PR TITLE
Issues 17 and 14

### DIFF
--- a/arcgis_api_for_python/check_completion_location.py
+++ b/arcgis_api_for_python/check_completion_location.py
@@ -282,7 +282,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=not arguments.skipSSLVerification)
 
     # Get the project and data
     workforce_project = arcgis.gis.Item(gis, arguments.projectId)
@@ -325,6 +325,7 @@ if __name__ == "__main__":
                         help='The distance tolerance to use (meters- based on SR of Assignments FL)')
     parser.add_argument('-minAccuracy', dest='minAccuracy', default=50,
                         help="The minimum accuracy to use (meters - based on SR of Assignments FL)")
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/copy_assignments_fs.py
+++ b/arcgis_api_for_python/copy_assignments_fs.py
@@ -144,7 +144,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
 
     # Get the project and data
     workforce_project = arcgis.gis.Item(gis, arguments.projectId)
@@ -207,6 +207,7 @@ if __name__ == "__main__":
                         required=True)
     parser.add_argument('-configFile', dest="configFile", help="The json configuration file to use", required=True)
     parser.add_argument('-logFile', dest='logFile', help="The log file to write to", required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/create_assignment_types.py
+++ b/arcgis_api_for_python/create_assignment_types.py
@@ -118,7 +118,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
     # Create a content manager object
     content_manager = arcgis.gis.ContentManager(gis)
     # Get the project and data
@@ -149,6 +149,7 @@ if __name__ == "__main__":
     parser.add_argument('-pid', dest='projectId', help="The id of the project to add assignments to", required=True)
     parser.add_argument('-csvFile', dest='csvFile', help="The path/name of the csv file to read")
     parser.add_argument('-logFile', dest='logFile', help='The log file to use', required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/create_assignments_from_csv.py
+++ b/arcgis_api_for_python/create_assignments_from_csv.py
@@ -102,7 +102,7 @@ def main(args):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(args.org_url, username=args.username, password=args.password, verify_cert=False)
+    gis = arcgis.gis.GIS(args.org_url, username=args.username, password=args.password, verify_cert= not args.skipSSLVerification)
     # Create a content manager object
     content_manager = arcgis.gis.ContentManager(gis)
     # Get the project and data
@@ -262,6 +262,7 @@ if __name__ == "__main__":
     parser.add_argument('-csvFile', dest='csvFile', help="The path/name of the csv file to read")
     parser.add_argument('-wkid', dest='wkid', help='The wkid that the x,y values are use', type=int, default=4326)
     parser.add_argument('-logFile', dest='logFile', help='The log file to use', required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/create_assignments_from_csv.py
+++ b/arcgis_api_for_python/create_assignments_from_csv.py
@@ -35,6 +35,11 @@ import arrow
 import dateutil
 
 
+def log_critical_and_raise_exception(message):
+    logging.getLogger().critical(message)
+    raise Exception(message)
+
+
 def initialize_logging(log_file):
     """
     Setup logging
@@ -88,8 +93,7 @@ def get_field_name(field_name, fl):
         if field_name == "Editor":
             return fl.properties["editFieldsInfo"]["editorField"]
     else:
-        logging.getLogger().critical("Field: {} does not exist".format(field_name))
-        raise Exception("Field: {} does not exist".format(field_name))
+        log_critical_and_raise_exception("Field: {} does not exist".format(field_name))
 
 
 def main(args):
@@ -112,8 +116,7 @@ def main(args):
     if dispatchers.features:
         dispatcher_id = dispatchers.features[0].attributes[get_field_name("OBJECTID", dispatcher_fl)]
     else:
-        logger.critical("{} is not a dispatcher".format(args.username))
-        return
+        log_critical_and_raise_exception("{} is not a dispatcher".format(args.username))
 
     # Get the codes of the domains
     statuses = []
@@ -151,6 +154,8 @@ def main(args):
         # Add optional attributes
         if args.dispatcherIdField: attributes[get_field_name("dispatcherId", assignment_fl)] = int(
             assignment[args.dispatcherIdField])
+        elif get_field_name("dispatcherId", assignment_fl) not in attributes:
+                attributes[get_field_name("dispatcherId", assignment_fl)] = dispatcher_id
         if args.descriptionField: attributes[get_field_name("description", assignment_fl)] = assignment[
             args.descriptionField]
         if args.priorityField: attributes[get_field_name("priority", assignment_fl)] = int(
@@ -172,8 +177,7 @@ def main(args):
             assignment_wrapper["attachmentFile"] = assignment[args.attachmentFileField]
 
         # Set the dispatcherId in the assignment json
-        if get_field_name("dispatcherId", assignment_fl) not in assignment_wrapper["assignment"].attributes:
-            assignment_wrapper["assignment"].attributes[get_field_name("dispatcherId", assignment_fl)] = dispatcher_id
+
 
         # set worker ids
         if "workerUsername" in assignment_wrapper and assignment_wrapper["workerUsername"]:
@@ -186,27 +190,24 @@ def main(args):
                 assignment_wrapper["assignment"].attributes[
                     get_field_name("assignedDate", assignment_fl)] = arrow.now().to('utc').timestamp * 1000
             else:
-                logger.critical("{} is not a worker".format(assignment_wrapper["workerUsername"]))
-                return
+                log_critical_and_raise_exception("{} is not a worker".format(assignment_wrapper["workerUsername"]))
 
         # Do some validation
+        dispatcher_ids = [x.attributes[get_field_name('OBJECTID', dispatcher_fl)] for x in dispatcher_fl.query().features]
+        if assignment_wrapper["assignment"].attributes[get_field_name("dispatcherId", assignment_fl)] not in dispatcher_ids:
+            log_critical_and_raise_exception("Invalid Dispatcher ID for: {}".format(assignment_wrapper["assignment"]))
         if assignment_wrapper["assignment"].attributes[get_field_name("status", assignment_fl)] not in statuses:
-            logging.getLogger().critical("Invalid Status for: {}".format(assignment_wrapper["assignment"]))
-            return
+            log_critical_and_raise_exception("Invalid Status for: {}".format(assignment_wrapper["assignment"]))
         if get_field_name("priority", assignment_fl) in assignment_wrapper["assignment"].attributes and \
                         assignment_wrapper["assignment"].attributes[
                             "priority"] not in priorities:
-            logging.getLogger().critical("Invalid Priority for: {}".format(assignment_wrapper["assignment"]))
-            return
+            log_critical_and_raise_exception("Invalid Priority for: {}".format(assignment_wrapper["assignment"]))
         if assignment_wrapper["assignment"].attributes[
             get_field_name("assignmentType", assignment_fl)] not in assignmentTypes:
-            logging.getLogger().critical("Invalid Assignment Type for: {}".format(assignment_wrapper["assignment"]))
-            return
+            log_critical_and_raise_exception("Invalid Assignment Type for: {}".format(assignment_wrapper["assignment"]))
         if "attachmentFile" in assignment_wrapper and assignment_wrapper["attachmentFile"]:
             if not os.path.isfile(os.path.abspath(assignment_wrapper["attachmentFile"])):
-                logging.getLogger().critical(
-                    "Attachment file not found: {}".format(assignment_wrapper["attachmentFile"]))
-                return
+                log_critical_and_raise_exception("Attachment file not found: {}".format(assignment_wrapper["attachmentFile"]))
         assignments_to_add.append(assignment_wrapper)
 
     # Add the assignments

--- a/arcgis_api_for_python/delete_assignment_types.py
+++ b/arcgis_api_for_python/delete_assignment_types.py
@@ -82,7 +82,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
     # Create a content manager object
     content_manager = arcgis.gis.ContentManager(gis)
     # Get the project and data
@@ -103,6 +103,7 @@ if __name__ == "__main__":
     # Parameters for workforce
     parser.add_argument('-pid', dest='projectId', help="The id of the project to add assignments to", required=True)
     parser.add_argument('-logFile', dest='logFile', help='The log file to use', required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/delete_assignments_by_query.py
+++ b/arcgis_api_for_python/delete_assignments_by_query.py
@@ -53,7 +53,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
 
     # Get the project and data
     workforce_project = arcgis.gis.Item(gis, arguments.projectId)
@@ -88,6 +88,7 @@ if __name__ == "__main__":
     group.add_argument('-where', dest='where', help="The where clause to use", default="1=1")
     group.add_argument('-objectIDs', dest='objectIDs', help="The objectIds to delete", nargs="+", default=[])
     parser.add_argument('-logFile', dest="logFile", help="The file to log to", required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
 
     args = parser.parse_args()
     try:

--- a/arcgis_api_for_python/export_assignments_to_csv.py
+++ b/arcgis_api_for_python/export_assignments_to_csv.py
@@ -148,7 +148,7 @@ def main(arguments):
         assignments = inject_field_names(assignments)
     # Write the assignments to the csv file
     logging.getLogger().info("Writing to CSV...")
-    assignments.save("", "exported.csv")
+    assignments.save("", arguments.outCSV)
     logging.getLogger().info("Completed")
 
 

--- a/arcgis_api_for_python/export_assignments_to_csv.py
+++ b/arcgis_api_for_python/export_assignments_to_csv.py
@@ -103,7 +103,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
 
     # Get the project and data
     workforce_project = arcgis.gis.Item(gis, arguments.projectId)
@@ -205,6 +205,7 @@ if __name__ == "__main__":
     parser.add_argument('-outSR', dest="outSR", help="The output spatial reference to use", default=None)
     parser.add_argument('-dateFormat', dest='dateFormat', help="The date format to use", default="%m/%d/%Y %H:%M:%S")
     parser.add_argument('-timezone', dest='timezone', default="UTC", help="The timezone to export to")
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)

--- a/arcgis_api_for_python/export_assignments_to_csv.py
+++ b/arcgis_api_for_python/export_assignments_to_csv.py
@@ -31,6 +31,11 @@ import arcgis
 import arrow
 
 
+def log_critical_and_raise_exception(message):
+    logging.getLogger().critical(message)
+    raise Exception(message)
+
+
 def initialize_logging(log_file):
     """
     Setup logging
@@ -84,8 +89,7 @@ def get_field_name(field_name, fl):
         if field_name == "Editor":
             return fl.properties["editFieldsInfo"]["editorField"]
     else:
-        logging.getLogger().critical("Field: {} does not exist".format(field_name))
-        raise Exception("Field: {} does not exist".format(field_name))
+        log_critical_and_raise_exception("Field: {} does not exist".format(field_name))
 
 
 def main(arguments):

--- a/arcgis_api_for_python/import_workers.py
+++ b/arcgis_api_for_python/import_workers.py
@@ -33,6 +33,11 @@ import traceback
 import arcgis
 
 
+def log_critical_and_raise_exception(message):
+    logging.getLogger().critical(message)
+    raise Exception(message)
+
+
 def user_exists(gis, username):
     """
     Searchs the organization/portal to see if a user exists
@@ -71,8 +76,7 @@ def get_field_name(field_name, fl):
         if field_name == "Editor":
             return fl.properties["editFieldsInfo"]["editorField"]
     else:
-        logging.getLogger().critical("Field: {} does not exist".format(field_name))
-        raise Exception("Field: {} does not exist".format(field_name))
+        log_critical_and_raise_exception("Field: {} does not exist".format(field_name))
 
 
 def initialize_logger(logFile):
@@ -129,12 +133,12 @@ def main(arguments):
             new_worker = arcgis.features.Feature(attributes=new_worker_attributes)
             # check if the user exists in the org
             if not user_exists(gis, new_worker.attributes[get_field_name("userId", workers_fl)]):
-                logger.warning("User '{}' does not exist in your org and will not be added".format(
+                log_critical_and_raise_exception("User '{}' does not exist in your org".format(
                     new_worker.attributes[get_field_name("userId", workers_fl)]))
             # check if user already is part of the project
             elif new_worker.attributes[get_field_name("userId", workers_fl)] in [
                 w.attributes[get_field_name("userId", workers_fl)] for w in current_workers]:
-                logger.warning("User '{}' is already part of this project and will not be added".format(
+                log_critical_and_raise_exception("User '{}' is already part of this project".format(
                     new_worker.attributes[get_field_name("userId", workers_fl)]))
             else:
                 workers.append(new_worker)

--- a/arcgis_api_for_python/import_workers.py
+++ b/arcgis_api_for_python/import_workers.py
@@ -108,7 +108,7 @@ def main(arguments):
     # Create the GIS
     logger.info("Authenticating...")
     # First step is to get authenticate and get a valid token
-    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert=False)
+    gis = arcgis.gis.GIS(arguments.org_url, username=arguments.username, password=arguments.password, verify_cert= not arguments.skipSSLVerification)
     # Get the project and data
     workforce_project = arcgis.gis.Item(gis, arguments.project_id)
     workforce_project_data = workforce_project.get_data()
@@ -178,6 +178,7 @@ if __name__ == "__main__":
                         help="The name of the column representing the contact number of the worker", default=None)
     parser.add_argument('-csvFile', dest='csvFile', help="The path/name of the csv file to read")
     parser.add_argument('-logFile', dest='logFile', help='The log file to use', required=True)
+    parser.add_argument('--skipSSL', dest='skipSSLVerification', action='store_true', help="Verify the SSL Certificate of the server")
     args = parser.parse_args()
     try:
         main(args)


### PR DESCRIPTION
Should address #17 and #14 

@jmdye can you try out these changes?

You can now specify `--skipSSL` flag to ignore the ssl certificate when making requests for all of the ArcGIS Python API scripts.

I changed the logic everywhere to raise and exception if there is "critical error". This should address the issue of having invalid assignments/workers added (or trying to be added at least).