### PR TITLE
Create Joined View

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ These scripts support Workforce in both ArcGIS Online and ArcGIS Enterprise.
 | [Report Incomplete Assignments with Work Orders ](report_incomplete_assignments_with_work_orders.md)               | [report_incomplete_assignments_with_work_orders.py](scripts/report_incomplete_assignments_with_work_orders.py)    
 | [Report Complete Assignments without Work Orders](report_complete_assignments_without_work_orders.md)               | [report_complete_assignments_without_work_orders.py](scripts/report_complete_assignments_without_work_orders.py)    
 | [Create Default Ops Dashboard](create_ops_dashboard.md)              | [create_ops_dashboard.py](scripts/create_ops_dashboard.py)|
+| [Create Joined View](create_joined_view.md) | [create_joined_view](scripts/created_joined_view.py) |
 
 ### Instructions
 

--- a/create_joined_view.md
+++ b/create_joined_view.md
@@ -1,6 +1,6 @@
 ## Create Joined View
 
-This script creates a joined hosted feature layer view that comabines the assignments, assignment types, workers, and dispatchers into a single layer. This allows information like the worker name to be displayed with the assignment even though the data is stored in two different layers.
+This script creates a joined hosted feature layer view that combines the assignments, assignment types, workers, and dispatchers into a single layer. This allows information like the worker name to be displayed with the assignment even though the data is stored in two different layers. This script only applies to offline-enabled Workforce projects.
 
 **This script requires the logged in user to be an admin or to be the owner of the project**
 
@@ -11,9 +11,9 @@ Supports Python 3.6+
 
 In addition to the authentication arguments, the script specific arguments are as follows:
 
-- -log-file \<logFile\> The log file to use for logging messages
-- -project-id \<projectId\> - The workforce project ID (from AGOL)
-- -name \<csvFile\> The name of the resulting layer (optional - a default name will be generated if not supplied)
+- -log-file \<log-file\> The log file to use for logging messages
+- -project-id \<project id\> - The workforce project ID (from AGOL)
+- -name \<output layer name\> The name of the resulting layer (optional - a default name will be generated if not supplied)
 
 ```bash
 python create_joined_view.py -org https://arcgis.com -u username -p password -project-id cc1ed9326f16474ba35679d34bb88691 -name "Example Joined View"

--- a/create_joined_view.md
+++ b/create_joined_view.md
@@ -1,0 +1,31 @@
+## Create Joined View
+
+This script creates a joined hosted feature layer view that comabines the assignments, assignment types, workers, and dispatchers into a single layer. This allows information like the worker name to be displayed with the assignment even though the data is stored in two different layers.
+
+**This script requires the logged in user to be an admin or to be the owner of the project**
+
+Supports Python 3.6+
+
+----
+
+
+In addition to the authentication arguments, the script specific arguments are as follows:
+
+- -log-file \<logFile\> The log file to use for logging messages
+- -project-id \<projectId\> - The workforce project ID (from AGOL)
+- -name \<csvFile\> The name of the resulting layer (optional - a default name will be generated if not supplied)
+
+```bash
+python create_joined_view.py -org https://arcgis.com -u username -p password -project-id cc1ed9326f16474ba35679d34bb88691 -name "Example Joined View"
+```
+
+## What it does
+
+ 1. First the script uses the provided credentials to authenticate with AGOL
+ 2. Then it creates a joined view layer between the assignments layer and the assignment types table
+ 3. Then it creates a joined view layer between the assignments layer and the workers layer
+ 4. Then it creates a joined view layer between the assignments layer and the dispatchers table
+ 5. Then it joins those previously joined layers together producing the final joined layer
+ 
+ The reason so many intermediate joined layers are created is due to limitations of the feature service which only allow a join between a max of 2 layers.
+

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -24,6 +24,7 @@
 """
 
 import argparse
+import datetime
 import logging
 import logging.handlers
 import sys
@@ -31,6 +32,153 @@ import traceback
 from arcgis.gis import GIS
 from arcgis.apps.workforce.project import Project
 from arcgis.features import FeatureLayerCollection
+
+
+# Define the set of fields to include for each layer in the joined layer
+
+assignment_type_fields = [
+    {
+        "name": "assignment_type_description",
+        "alias": "Assignment Type",
+        "source": "description"
+    }
+]
+
+
+assignment_fields = [
+    {
+        "name": "description",
+        "alias": "Description",
+        "source": "description"
+    },
+    {
+        "name": "status",
+        "alias": "Status",
+        "source": "status"
+    },
+    {
+        "name": "notes",
+        "alias": "Notes",
+        "source": "notes"
+    },
+    {
+        "name": "priority",
+        "alias": "Priority",
+        "source": "priority"
+    },
+    {
+        "name": "workorderid",
+        "alias": "WorkOrder ID",
+        "source": "workorderid"
+    },
+    {
+        "name": "duedate",
+        "alias": "Due Date",
+        "source": "duedate"
+    },
+    {
+        "name": "GlobalID",
+        "alias": "GlobalID",
+        "source": "GlobalID"
+    },
+    {
+        "name": "location",
+        "alias": "Location",
+        "source": "location"
+    },
+    {
+        "name": "declinedcomment",
+        "alias": "Declined Comment",
+        "source": "declinedcomment"
+    },
+    {
+        "name": "assigneddate",
+        "alias": "Assigned on Date",
+        "source": "assigneddate"
+    },
+    {
+        "name": "inprogressdate",
+        "alias": "In Progress Date",
+        "source": "inprogressdate"
+    },
+    {
+        "name": "completeddate",
+        "alias": "Completed on Date",
+        "source": "completeddate"
+    },
+    {
+        "name": "declineddate",
+        "alias": "Declined on Date",
+        "source": "declineddate"
+    },
+    {
+        "name": "pauseddate",
+        "alias": "Paused on Date",
+        "source": "pauseddate"
+    },
+    {
+        "name": "CreationDate",
+        "alias": "Creation Date",
+        "source": "CreationDate"
+    },
+    {
+        "name": "Creator",
+        "alias": "Creator",
+        "source": "Creator"
+    },
+    {
+        "name": "EditDate",
+        "alias": "Edit Date",
+        "source": "EditDate"
+    },
+    {
+        "name": "Editor",
+        "alias": "Editor",
+        "source": "Editor"
+    }
+]
+
+
+worker_fields = [
+    {
+        "name": "worker_name",
+        "alias": "Worker Name",
+        "source": "name"
+    },
+    {
+        "name": "worker_title",
+        "alias": "Worker Title",
+        "source": "title"
+    },
+    {
+        "name": "worker_status",
+        "alias": "Worker Status",
+        "source": "status"
+    },
+    {
+        "name": "worker_contactnumber",
+        "alias": "Worker Contact Number",
+        "source": "contactnumber"
+    },
+    {
+        "name": "worker_notes",
+        "alias": "Worker Notes",
+        "source": "notes"
+    }
+]
+
+dispatcher_fields = [
+    {
+        "name": "dispatcher_name",
+        "alias": "Dispatcher Name",
+        "source": "name"
+    },
+    {
+        "name": "dispatcher_contactnumber",
+        "alias": "Dispatcher Contact Number",
+        "source": "contactnumber"
+    }
+]
 
 
 def create_joined_view(gis, source_layer, join_layer, primary_key_field, foreign_key_field, name, source_fields,
@@ -85,186 +233,13 @@ def create_joined_view(gis, source_layer, join_layer, primary_key_field, foreign
     return new_item
 
 
-def assignment_type_fields(use_joined_name=False):
+def change_source_field_name_to_joined_field_name(fields):
     """
-    Creates the list of field configuration objects to use in the joined layer
-    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
-    :return: List of field configuration objects
+    Switches the source of the field name to be the name of the field after it was added to a joined layer
+    :param fields: The list of field objects
     """
-    fields = [
-        {
-            "name": "assignment_type_description",
-            "alias": "Assignment Type",
-            "source": "description"
-        }
-    ]
-    if use_joined_name:
-        for f in fields:
-            f["source"] = f["name"]
-    return fields
-
-
-def worker_fields(use_joined_name=False):
-    """
-    Creates the list of field configuration objects to use in the joined layer
-    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
-    :return: List of field configuration objects
-    """
-    fields = [
-        {
-            "name": "worker_name",
-            "alias": "Worker Name",
-            "source": "name"
-        },
-        {
-            "name": "worker_title",
-            "alias": "Worker Title",
-            "source": "title"
-        },
-        {
-            "name": "worker_status",
-            "alias": "Worker Status",
-            "source": "status"
-        },
-        {
-            "name": "worker_contactnumber",
-            "alias": "Worker Contact Number",
-            "source": "contactnumber"
-        },
-        {
-            "name": "worker_notes",
-            "alias": "Worker Notes",
-            "source": "notes"
-        }
-    ]
-    if use_joined_name:
-        for f in fields:
-            f["source"] = f["name"]
-    return fields
-
-
-def dispatcher_fields(use_joined_name=False):
-    """
-    Creates the list of field configuration objects to use in the joined layer
-    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
-    :return: List of field configuration objects
-    """
-    fields = [
-        {
-            "name": "dispatcher_name",
-            "alias": "Dispatcher Name",
-            "source": "name"
-        },
-        {
-            "name": "dispatcher_contactnumber",
-            "alias": "Dispatcher Contact Number",
-            "source": "contactnumber"
-        }
-    ]
-    if use_joined_name:
-        for f in fields:
-            f["source"] = f["name"]
-    return fields
-
-
-def assignment_fields():
-    """
-    Creates the list of field configuration objects to use in the joined layer
-    :return: List of field configuration objects
-    """
-    fields = [
-        {
-            "name": "description",
-            "alias": "Description",
-            "source": "description"
-        },
-        {
-            "name": "status",
-            "alias": "Status",
-            "source": "status"
-        },
-        {
-            "name": "notes",
-            "alias": "Notes",
-            "source": "notes"
-        },
-        {
-            "name": "priority",
-            "alias": "Priority",
-            "source": "priority"
-        },
-        {
-            "name": "workorderid",
-            "alias": "WorkOrder ID",
-            "source": "workorderid"
-        },
-        {
-            "name": "duedate",
-            "alias": "Due Date",
-            "source": "duedate"
-        },
-        {
-            "name": "GlobalID",
-            "alias": "GlobalID",
-            "source": "GlobalID"
-        },
-        {
-            "name": "location",
-            "alias": "Location",
-            "source": "location"
-        },
-        {
-            "name": "declinedcomment",
-            "alias": "Declined Comment",
-            "source": "declinedcomment"
-        },
-        {
-            "name": "assigneddate",
-            "alias": "Assigned on Date",
-            "source": "assigneddate"
-        },
-        {
-            "name": "inprogressdate",
-            "alias": "In Progress Date",
-            "source": "inprogressdate"
-        },
-        {
-            "name": "completeddate",
-            "alias": "Completed on Date",
-            "source": "completeddate"
-        },
-        {
-            "name": "declineddate",
-            "alias": "Declined on Date",
-            "source": "declineddate"
-        },
-        {
-            "name": "pauseddate",
-            "alias": "Paused on Date",
-            "source": "pauseddate"
-        },
-        {
-            "name": "CreationDate",
-            "alias": "Creation Date",
-            "source": "CreationDate"
-        },
-        {
-            "name": "Creator",
-            "alias": "Creator",
-            "source": "Creator"
-        },
-        {
-            "name": "EditDate",
-            "alias": "Edit Date",
-            "source": "EditDate"
-        },
-        {
-            "name": "Editor",
-            "alias": "Editor",
-            "source": "Editor"
-        }
-    ]
-    return fields
+    for f in fields:
+        f["source"] = f["name"]
 
 
 def generate_layer_definition(source_layer, join_layer, primary_key_field, foreign_key_field, name, source_fields,
@@ -351,7 +326,9 @@ def main(args):
 
     # Create the GIS
     logger.info("Authenticating...")
-    gis = GIS(args.org, args.username, args.password)
+    gis = GIS(args.org, args.username, args.password, verify_cert=not args.skip_ssl_verification)
+    if gis.properties["isPortal"]:
+        raise RuntimeError("This script only works with ArcGIS Online")
     logger.info("Getting Workforce Project...")
     item = gis.content.get(args.project_id)
     if item is None:
@@ -359,53 +336,60 @@ def main(args):
     project = Project(gis.content.get(args.project_id))
     if int(project.version.split(".")[0]) < 2:
         raise RuntimeError("This script only works with offline-enabled projects")
-    logger.info("Phase 1: Joining assignments and assignment types...")
+    logger.info("Phase 1: Joining assignments to assignment types...")
+    d = int(datetime.datetime.now().timestamp())
     assignments_to_types = create_joined_view(gis,
                                               project.assignments_layer,
                                               project.assignment_types_table,
                                               project._assignment_schema.assignment_type,
                                               project._assignment_types.global_id,
-                                              f"{project.title}_IntermediateView0",
-                                              assignment_fields(),
-                                              assignment_type_fields())
-    logger.info("Phase 2: Joining assignments and workers...")
+                                              f"{project.title} Intermediate View 0 {d}",
+                                              assignment_fields,
+                                              assignment_type_fields)
+    logger.info("Phase 2: Joining assignments to workers...")
     assignments_to_workers = create_joined_view(gis,
                                                 project.assignments_layer,
                                                 project.workers_layer,
                                                 project._assignment_schema.worker_id,
                                                 project._worker_schema.global_id,
-                                                f"{project.title}_IntermediateView1",
-                                                assignment_fields(),
-                                                worker_fields(),
+                                                f"{project.title} Intermediate View 1 {d}",
+                                                assignment_fields,
+                                                worker_fields,
                                                 )
-    logger.info("Phase 3: Joining assignments, assignment types, and workers...")
-    assignments_types_workers = create_joined_view(gis,
-                                                   assignments_to_types.layers[0],
-                                                   assignments_to_workers.layers[0],
-                                                   project._assignment_schema.global_id,
-                                                   project._assignment_schema.global_id,
-                                                   f"{project.title}_IntermediateView2",
-                                                   assignment_type_fields(True) + assignment_fields(),
-                                                   worker_fields(True))
-    logger.info("Phase 4: Joining assignments and dispatchers...")
+    logger.info("Phase 3: Joining assignments to dispatchers...")
     assignments_to_dispatchers = create_joined_view(gis,
                                                     project.assignments_layer,
                                                     project.dispatchers_layer,
                                                     project._assignment_schema.dispatcher_id,
                                                     project._dispatcher_schema.global_id,
-                                                    f"{project.title}_IntermediateView3",
-                                                    assignment_fields(),
-                                                    dispatcher_fields())
-    logger.info("Phase 5: Joining assignments, assignment types, workers, and dispatchers...")
+                                                    f"{project.title} Intermediate View 2 {d}",
+                                                    assignment_fields,
+                                                    dispatcher_fields)
+    change_source_field_name_to_joined_field_name(assignment_type_fields)
+    change_source_field_name_to_joined_field_name(worker_fields)
+    change_source_field_name_to_joined_field_name(dispatcher_fields)
+    logger.info("Phase 4: Joining assignments and assignment types to assignments and workers...")
+    assignments_types_workers = create_joined_view(gis,
+                                                   assignments_to_types.layers[0],
+                                                   assignments_to_workers.layers[0],
+                                                   project._assignment_schema.global_id,
+                                                   project._assignment_schema.global_id,
+                                                   f"{project.title} Intermediate View 3 {d}",
+                                                   assignment_type_fields + assignment_fields,
+                                                   worker_fields)
+    logger.info("Phase 5: Joining assignments and types and workers to  assignments and workers...")
+    if args.name:
+        name = args.name
+    else:
+        name = f"{project.title} Joined View {d}"
     final_item = create_joined_view(gis,
                                     assignments_types_workers.layers[0],
                                     assignments_to_dispatchers.layers[0],
                                     project._assignment_schema.global_id,
                                     project._assignment_schema.global_id,
-                                    f"{project.title}_Joined_View",
-                                    assignment_fields() + assignment_type_fields(
-                                        True) + worker_fields(True),
-                                    dispatcher_fields(True))
+                                    name,
+                                    assignment_fields + assignment_type_fields+ worker_fields,
+                                    dispatcher_fields)
     logger.info(f"Final Item: {final_item.title}")
     logger.info("Completed")
 
@@ -420,6 +404,7 @@ if __name__ == "__main__":
     parser.add_argument('-log-file', dest="log_file", help="The file to log to")
     parser.add_argument('--skip-ssl-verification', dest='skip_ssl_verification', action='store_true',
                         help="Verify the SSL Certificate of the server")
+    parser.add_argument('-n', dest='name', help="The name of the resulting joined view")
     args = parser.parse_args()
     try:
         main(args)

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -1,0 +1,133 @@
+import argparse
+from arcgis.gis import GIS
+from arcgis.apps.workforce.project import Project
+from arcgis.features import FeatureLayerCollection
+
+
+def create_joined_view(gis, source_layer, join_layer, primary_key_ield, foreign_key_field, name):
+    new_item = gis.content.create_service(
+        name=name,
+        is_view=True,
+        create_params={
+            "currentVersion": 10.2,
+            "serviceDescription": "",
+            "hasVersionedData": False,
+            "supportsDisconnectedEditing": False,
+            "hasStaticData": True,
+            "maxRecordCount": 2000,
+            "supportedQueryFormats": "JSON",
+            "capabilities": "Query",
+            "description": "",
+            "copyrightText": "",
+            "allowGeometryUpdates": False,
+            "syncEnabled": False,
+            "editorTrackingInfo": {
+                "enableEditorTracking": False,
+                "enableOwnershipAccessControl": False,
+                "allowOthersToUpdate": True,
+                "allowOthersToDelete": True
+            },
+            "xssPreventionInfo": {
+                "xssPreventionEnabled": True,
+                "xssPreventionRule": "InputOnly",
+                "xssInputRule": "rejectInvalid"
+            },
+            "tables": [
+
+            ],
+            "name": f"{name}"
+        }
+    )
+    fc = FeatureLayerCollection.fromitem(new_item)
+    layer_def = generate_layer_definition(source_layer, join_layer, primary_key_ield, foreign_key_field, name)
+    fc.manager.add_to_definition(layer_def)
+    return new_item
+
+
+def generate_fields(layer, add_suffix=False):
+    fields = []
+    suffix = ""
+    if add_suffix:
+        suffix = f'_{layer.properties["name"].replace(" ", "_")}'
+    for f in layer.properties["fields"]:
+        if f["name"].lower() == layer.properties["objectIdField"].lower():
+            continue
+        fields.append({
+            "name": f'{f["name"]}{suffix}',
+            "alias": f["alias"],
+            "source": f["name"]
+        })
+    return fields
+
+
+def generate_layer_definition(source_layer, join_layer, primary_key_field, foreign_key_field, name):
+    join_service_name = join_layer.url.split("/")[-3]
+    source_service_name = source_layer.url.split("/")[-3]
+    layer_def = {
+        "layers": [
+            {
+                "name": f"{name}",
+                "displayField": "",
+                "description": "AttributeJoin",
+                "adminLayerInfo": {
+                    "viewLayerDefinition": {
+                        "table": {
+                            "name": f"{source_service_name}_target",
+                            "sourceServiceName": f"{source_service_name}",
+                            "sourceLayerId": source_layer.properties["id"],
+                            "sourceLayerFields": generate_fields(source_layer),
+                            "relatedTables": [
+                                {
+                                    "name": f"{join_service_name}_join",
+                                    "sourceServiceName": f"{join_service_name}",
+                                    "sourceLayerId": join_layer.properties["id"],
+                                    "sourceLayerFields": generate_fields(join_layer, add_suffix=True),
+                                    "type": "LEFT",
+                                    "parentKeyFields": [
+                                        f"{primary_key_field}"
+                                    ],
+                                    "keyFields": [
+                                        f"{foreign_key_field}"
+                                    ],
+                                    "topFilter": {
+                                        "groupByFields": "GlobalID",
+                                        "orderByFields": "OBJECTID ASC",
+                                        "topCount": 1
+                                    }
+                                }
+                            ],
+                            "materialized": False
+                        }
+                    },
+                    "geometryField": {
+                        "name": f"{source_service_name}_target.Shape"
+                    }
+                }
+            }
+        ]
+    }
+    return layer_def
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', dest='username', help="The username to authenticate with", required=True)
+    parser.add_argument('-p', dest='password', help="The password to authenticate with", required=True)
+    parser.add_argument('-org', dest='org', help="The url of the org/portal to use", required=True)
+    # Parameters for workforce
+    parser.add_argument('-project-id', dest='project_id', help="The id of the project to create the view from", required=True)
+    args = parser.parse_args()
+    gis = GIS(args.org, args.username, args.password)
+    project = Project(gis.content.get(args.project_id))
+    assignments_to_types = create_joined_view(gis,
+                                              project.assignments_layer,
+                                              project.assignment_types_table,
+                                              project._assignment_schema.assignment_type,
+                                              project._assignment_types.global_id,
+                                              "AssignmentsToTypes")
+    assignments_to_workers = create_joined_view(gis,
+                                              project.assignments_layer,
+                                              project.workers_layer,
+                                              project._assignment_schema.worker_id,
+                                              project._worker_schema.global_id,
+                                              "AssignmentsToWorkers")

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -1,10 +1,26 @@
 import argparse
+import logging
+import logging.handlers
+import sys
 from arcgis.gis import GIS
 from arcgis.apps.workforce.project import Project
 from arcgis.features import FeatureLayerCollection
 
 
-def create_joined_view(gis, source_layer, join_layer, primary_key_ield, foreign_key_field, name):
+def create_joined_view(gis, source_layer, join_layer, primary_key_field, foreign_key_field, name, source_fields,
+                       join_fields):
+    """
+    Create a joined layer view between 2 layers
+    :param gis: The gis to create the layer with
+    :param source_layer: The source layer to join
+    :param join_layer: The layer to join with the source layer
+    :param primary_key_field: The primary key field in the source layer
+    :param foreign_key_field: The foreign key field in the join layer
+    :param name: The name of the new layer that will be created
+    :param source_fields: The list of field configuration objects in the source layer to keep in the resulting joined layer
+    :param join_fields: The list of field configuration objects in the join layer to keep in the resulting joined layer
+    :return: The new item
+    """
     new_item = gis.content.create_service(
         name=name,
         is_view=True,
@@ -39,28 +55,202 @@ def create_joined_view(gis, source_layer, join_layer, primary_key_ield, foreign_
         }
     )
     fc = FeatureLayerCollection.fromitem(new_item)
-    layer_def = generate_layer_definition(source_layer, join_layer, primary_key_ield, foreign_key_field, name)
+    layer_def = generate_layer_definition(source_layer, join_layer, primary_key_field, foreign_key_field, name,
+                                          source_fields, join_fields)
     fc.manager.add_to_definition(layer_def)
     return new_item
 
 
-def generate_fields(layer, add_suffix=False):
-    fields = []
-    suffix = ""
-    if add_suffix:
-        suffix = f'_{layer.properties["name"].replace(" ", "_")}'
-    for f in layer.properties["fields"]:
-        if f["name"].lower() == layer.properties["objectIdField"].lower():
-            continue
-        fields.append({
-            "name": f'{f["name"]}{suffix}',
-            "alias": f["alias"],
-            "source": f["name"]
-        })
+def assignment_type_fields(use_joined_name=False):
+    """
+    Creates the list of field configuration objects to use in the joined layer
+    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
+    :return: List of field configuration objects
+    """
+    fields = [
+        {
+            "name": "assignment_type_description",
+            "alias": "Assignment Type",
+            "source": "description"
+        }
+    ]
+    if use_joined_name:
+        for f in fields:
+            f["source"] = f["name"]
     return fields
 
 
-def generate_layer_definition(source_layer, join_layer, primary_key_field, foreign_key_field, name):
+def worker_fields(use_joined_name=False):
+    """
+    Creates the list of field configuration objects to use in the joined layer
+    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
+    :return: List of field configuration objects
+    """
+    fields = [
+        {
+            "name": "worker_name",
+            "alias": "Worker Name",
+            "source": "name"
+        },
+        {
+            "name": "worker_status",
+            "alias": "Worker Status",
+            "source": "status"
+        },
+        {
+            "name": "worker_contactnumber",
+            "alias": "Worker Contact Number",
+            "source": "contactnumber"
+        },
+        {
+            "name": "worker_notes",
+            "alias": "Worker Notes",
+            "source": "notes"
+        }
+    ]
+    if use_joined_name:
+        for f in fields:
+            f["source"] = f["name"]
+    return fields
+
+
+def dispatcher_fields(use_joined_name=False):
+    """
+    Creates the list of field configuration objects to use in the joined layer
+    :param use_joined_name: Determines if the source field should be the same as the name (used when creating a view on a view)
+    :return: List of field configuration objects
+    """
+    fields = [
+        {
+            "name": "dispatcher_name",
+            "alias": "Dispatcher Name",
+            "source": "name"
+        },
+        {
+            "name": "dispatcher_contactnumber",
+            "alias": "Dispatcher Contact Number",
+            "source": "contactnumber"
+        }
+    ]
+    if use_joined_name:
+        for f in fields:
+            f["source"] = f["name"]
+    return fields
+
+
+def assignment_fields():
+    """
+    Creates the list of field configuration objects to use in the joined layer
+    :return: List of field configuration objects
+    """
+    fields = [
+        {
+            "name": "description",
+            "alias": "Description",
+            "source": "description"
+        },
+        {
+            "name": "status",
+            "alias": "Status",
+            "source": "status"
+        },
+        {
+            "name": "notes",
+            "alias": "Notes",
+            "source": "notes"
+        },
+        {
+            "name": "priority",
+            "alias": "Priority",
+            "source": "priority"
+        },
+        {
+            "name": "workorderid",
+            "alias": "WorkOrder ID",
+            "source": "workorderid"
+        },
+        {
+            "name": "duedate",
+            "alias": "Due Date",
+            "source": "duedate"
+        },
+        {
+            "name": "GlobalID",
+            "alias": "GlobalID",
+            "source": "GlobalID"
+        },
+        {
+            "name": "location",
+            "alias": "Location",
+            "source": "location"
+        },
+        {
+            "name": "declinedcomment",
+            "alias": "Declined Comment",
+            "source": "declinedcomment"
+        },
+        {
+            "name": "assigneddate",
+            "alias": "Assigned on Date",
+            "source": "assigneddate"
+        },
+        {
+            "name": "inprogressdate",
+            "alias": "In Progress Date",
+            "source": "inprogressdate"
+        },
+        {
+            "name": "completeddate",
+            "alias": "Completed on Date",
+            "source": "completeddate"
+        },
+        {
+            "name": "declineddate",
+            "alias": "Declined on Date",
+            "source": "declineddate"
+        },
+        {
+            "name": "pauseddate",
+            "alias": "Paused on Date",
+            "source": "pauseddate"
+        },
+        {
+            "name": "CreationDate",
+            "alias": "Creation Date",
+            "source": "CreationDate"
+        },
+        {
+            "name": "Creator",
+            "alias": "Creator",
+            "source": "Creator"
+        },
+        {
+            "name": "EditDate",
+            "alias": "Edit Date",
+            "source": "EditDate"
+        },
+        {
+            "name": "Editor",
+            "alias": "Editor",
+            "source": "Editor"
+        }
+    ]
+    return fields
+
+
+def generate_layer_definition(source_layer, join_layer, primary_key_field, foreign_key_field, name, source_fields,
+                              join_fields):
+    """
+    Create layer definition for a joined layer view between 2 layers
+    :param source_layer: The source layer to join
+    :param join_layer: The layer to join with the source layer
+    :param primary_key_field: The primary key field in the source layer
+    :param foreign_key_field: The foreign key field in the join layer
+    :param name: The name of the new layer that will be created
+    :param source_fields: The list of field configuration objects in the source layer to keep in the resulting joined layer
+    :param join_fields: The list of field configuration objects in the join layer to keep in the resulting joined layer
+    :return: The layer definition
+    """
     join_service_name = join_layer.url.split("/")[-3]
     source_service_name = source_layer.url.split("/")[-3]
     layer_def = {
@@ -75,13 +265,13 @@ def generate_layer_definition(source_layer, join_layer, primary_key_field, forei
                             "name": f"{source_service_name}_target",
                             "sourceServiceName": f"{source_service_name}",
                             "sourceLayerId": source_layer.properties["id"],
-                            "sourceLayerFields": generate_fields(source_layer),
+                            "sourceLayerFields": source_fields,
                             "relatedTables": [
                                 {
                                     "name": f"{join_service_name}_join",
                                     "sourceServiceName": f"{join_service_name}",
                                     "sourceLayerId": join_layer.properties["id"],
-                                    "sourceLayerFields": generate_fields(join_layer, add_suffix=True),
+                                    "sourceLayerFields": join_fields,
                                     "type": "LEFT",
                                     "parentKeyFields": [
                                         f"{primary_key_field}"
@@ -109,43 +299,93 @@ def generate_layer_definition(source_layer, join_layer, primary_key_field, forei
     return layer_def
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-u', dest='username', help="The username to authenticate with", required=True)
-    parser.add_argument('-p', dest='password', help="The password to authenticate with", required=True)
-    parser.add_argument('-org', dest='org', help="The url of the org/portal to use", required=True)
-    # Parameters for workforce
-    parser.add_argument('-project-id', dest='project_id', help="The id of the project to create the view from", required=True)
-    args = parser.parse_args()
+def main(args):
+    # initialize logging
+    formatter = logging.Formatter("[%(asctime)s] [%(filename)30s:%(lineno)4s - %(funcName)30s()]\
+                [%(threadName)5s] [%(name)10.10s] [%(levelname)8s] %(message)s")
+    # Grab the root logger
+    logger = logging.getLogger()
+    # Set the root logger logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    logger.setLevel(logging.DEBUG)
+    # Create a handler to print to the console
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(formatter)
+    sh.setLevel(logging.INFO)
+    # Create a handler to log to the specified file
+    if args.log_file:
+        rh = logging.handlers.RotatingFileHandler(args.log_file, mode='a', maxBytes=10485760)
+        rh.setFormatter(formatter)
+        rh.setLevel(logging.DEBUG)
+        logger.addHandler(rh)
+    # Add the handlers to the root logger
+    logger.addHandler(sh)
+
+    # Create the GIS
+    logger.info("Authenticating...")
     gis = GIS(args.org, args.username, args.password)
+    logger.info("Getting Workforce Project...")
     project = Project(gis.content.get(args.project_id))
+    logger.info("Phase 1: Joining assignments and assignment types...")
     assignments_to_types = create_joined_view(gis,
                                               project.assignments_layer,
                                               project.assignment_types_table,
                                               project._assignment_schema.assignment_type,
                                               project._assignment_types.global_id,
-                                              "AssignmentsToTypes5")
+                                              f"{project.title}_IntermediateView0",
+                                              assignment_fields(),
+                                              assignment_type_fields())
+    logger.info("Phase 2: Joining assignments and workers...")
     assignments_to_workers = create_joined_view(gis,
-                                              project.assignments_layer,
-                                              project.workers_layer,
-                                              project._assignment_schema.worker_id,
-                                              project._worker_schema.global_id,
-                                              "AssignmentsToWorkers5")
-    assignments_to_dispatchers = create_joined_view(gis,
-                                                    project.assignments_layer,
-                                                    project.dispatchers_layer,
-                                                    project._assignment_schema.dispatcher_id,
-                                                    project._dispatcher_schema.global_id,
-                                                    "AssignmentsToDispatchers5")
+                                                project.assignments_layer,
+                                                project.workers_layer,
+                                                project._assignment_schema.worker_id,
+                                                project._worker_schema.global_id,
+                                                f"{project.title}_IntermediateView1",
+                                                assignment_fields(),
+                                                worker_fields(),
+                                                )
+    logger.info("Phase 3: Joining assignments, assignment types, and workers...")
     assignments_types_workers = create_joined_view(gis,
                                                    assignments_to_types.layers[0],
                                                    assignments_to_workers.layers[0],
                                                    project._assignment_schema.global_id,
                                                    project._assignment_schema.global_id,
-                                                   "AssignmentsToTypesToWorkers5")
-    assignment_types_workers_dispatchers = create_joined_view(gis,
-                                                              assignments_types_workers.layers[0],
-                                                              assignments_to_dispatchers.layers[0],
-                                                              project._assignment_schema.global_id,
-                                                              project._assignment_schema.global_id,
-                                                              "AssignmentsToTypesToWorkersToDispatchers5")
+                                                   f"{project.title}_IntermediateView2",
+                                                   assignment_type_fields(True) + assignment_fields(),
+                                                   worker_fields(True))
+    logger.info("Phase 4: Joining assignments and dispatchers...")
+    assignments_to_dispatchers = create_joined_view(gis,
+                                                    project.assignments_layer,
+                                                    project.dispatchers_layer,
+                                                    project._assignment_schema.dispatcher_id,
+                                                    project._dispatcher_schema.global_id,
+                                                    f"{project.title}_IntermediateView3",
+                                                    assignment_fields(),
+                                                    dispatcher_fields())
+    logger.info("Phase 5: Joining assignments, assignment types, workers, and dispatchers...")
+    final_item = create_joined_view(gis,
+                                    assignments_types_workers.layers[0],
+                                    assignments_to_dispatchers.layers[0],
+                                    project._assignment_schema.global_id,
+                                    project._assignment_schema.global_id,
+                                    f"{project.title}_Joined_View",
+                                    assignment_fields() + assignment_type_fields(
+                                        True) + worker_fields(True),
+                                    dispatcher_fields(True))
+    logger.info(f"Final Item: {final_item.title}")
+    logger.info("Completed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', dest='username', help="The username to authenticate with", required=True)
+    parser.add_argument('-p', dest='password', help="The password to authenticate with", required=True)
+    parser.add_argument('-org', dest='org', help="The url of the org/portal to use", required=True)
+    parser.add_argument('-project-id', dest='project_id', help="The id of the project to create the view from",
+                        required=True)
+    parser.add_argument('-log-file', dest="log_file", help="The file to log to")
+    parser.add_argument('--skip-ssl-verification', dest='skip_ssl_verification', action='store_true',
+                        help="Verify the SSL Certificate of the server")
+    args = parser.parse_args()
+    main(args)
+

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -124,10 +124,28 @@ if __name__ == "__main__":
                                               project.assignment_types_table,
                                               project._assignment_schema.assignment_type,
                                               project._assignment_types.global_id,
-                                              "AssignmentsToTypes")
+                                              "AssignmentsToTypes5")
     assignments_to_workers = create_joined_view(gis,
                                               project.assignments_layer,
                                               project.workers_layer,
                                               project._assignment_schema.worker_id,
                                               project._worker_schema.global_id,
-                                              "AssignmentsToWorkers")
+                                              "AssignmentsToWorkers5")
+    assignments_to_dispatchers = create_joined_view(gis,
+                                                    project.assignments_layer,
+                                                    project.dispatchers_layer,
+                                                    project._assignment_schema.dispatcher_id,
+                                                    project._dispatcher_schema.global_id,
+                                                    "AssignmentsToDispatchers5")
+    assignments_types_workers = create_joined_view(gis,
+                                                   assignments_to_types.layers[0],
+                                                   assignments_to_workers.layers[0],
+                                                   project._assignment_schema.global_id,
+                                                   project._assignment_schema.global_id,
+                                                   "AssignmentsToTypesToWorkers5")
+    assignment_types_workers_dispatchers = create_joined_view(gis,
+                                                              assignments_types_workers.layers[0],
+                                                              assignments_to_dispatchers.layers[0],
+                                                              project._assignment_schema.global_id,
+                                                              project._assignment_schema.global_id,
+                                                              "AssignmentsToTypesToWorkersToDispatchers5")

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -404,7 +404,7 @@ if __name__ == "__main__":
     parser.add_argument('-log-file', dest="log_file", help="The file to log to")
     parser.add_argument('--skip-ssl-verification', dest='skip_ssl_verification', action='store_true',
                         help="Verify the SSL Certificate of the server")
-    parser.add_argument('-n', dest='name', help="The name of the resulting joined view")
+    parser.add_argument('-name', dest='name', help="The name of the resulting joined view")
     args = parser.parse_args()
     try:
         main(args)


### PR DESCRIPTION
This PR adds a new script for Workforce V2 which allows the project owner to create a hosted view that joins the assignments, types, workers, and dispatchers into a single layer. This is useful for showing in Operations Dashboard. 

The REST API only supports joining 2 layers but you can join a view to another view. It creates a series of intermediate views leading up to the final view.

@crai3162 thought it was worth publishing and linking to in the EAP site.

To do:
- [x] add readme file for this script
- [x] update main readme file