### PR TITLE
Create dashboard with joined view layer

### DIFF
--- a/create_joined_view.md
+++ b/create_joined_view.md
@@ -3,7 +3,7 @@
 This script creates a joined hosted feature layer view that combines the assignments, assignment types, workers, and dispatchers into a single layer. This allows information like the worker name to be displayed with the assignment even though the data is stored in two different layers. This script only applies to offline-enabled Workforce projects.
 
 Additionally, this script can be used to create a simple Workforce dashboard showing assignments and workers. This
-differs from `create_ops_dashboard.py` in that the assignment types should show names rather than global ids, using
+differs from `create_ops_dashboard.py` in that the assignment types in the dashboard should show names rather than global ids, using
 the joined view created above.
 
 **This script requires the logged in user to be an admin or to be the owner of the project**

--- a/create_joined_view.md
+++ b/create_joined_view.md
@@ -2,6 +2,10 @@
 
 This script creates a joined hosted feature layer view that combines the assignments, assignment types, workers, and dispatchers into a single layer. This allows information like the worker name to be displayed with the assignment even though the data is stored in two different layers. This script only applies to offline-enabled Workforce projects.
 
+Additionally, this script can be used to create a simple Workforce dashboard showing assignments and workers. This
+differs from `create_ops_dashboard.py` in that the assignment types should show names rather than global ids, using
+the joined view created above.
+
 **This script requires the logged in user to be an admin or to be the owner of the project**
 
 Supports Python 3.6+
@@ -14,9 +18,10 @@ In addition to the authentication arguments, the script specific arguments are a
 - -log-file \<log-file\> The log file to use for logging messages
 - -project-id \<project id\> - The workforce project ID (from AGOL). This is the item ID of the Workforce feature service (also found in the web app URL "projects/{project_id}/dispatch")
 - -name \<output layer name\> The name of the resulting layer (optional - a default name will be generated if not supplied)
+- --create-dashboard - if provided, create a Dashboard for monitoring your Workforce project with your new joined view layer. AGOL only 
 
 ```bash
-python create_joined_view.py -org https://arcgis.com -u username -p password -project-id cc1ed9326f16474ba35679d34bb88691 -name "Example Joined View"
+python create_joined_view.py -org https://arcgis.com -u username -p password -project-id cc1ed9326f16474ba35679d34bb88691 -name "Example Joined View" --create-dashboard
 ```
 
 ## What it does

--- a/create_ops_dashboard.md
+++ b/create_ops_dashboard.md
@@ -20,7 +20,7 @@ In addition to the authentication arguments (org, username, password), the scrip
 
 Example Usage:
 ```bash
-python create_ops_dashboard.py -u <username> -p <password> -org https://arcgis.com -project-id <project_id> --light-mode --clone-map
+python create_ops_dashboard.py -u <username> -p <password> -org https://arcgis.com -project-id <project_id> --light-mode --use-dispatcher-webmap
 ```
 
 ## What it does

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -410,8 +410,9 @@ def main(args):
         # swizzle in joined layer instead of assignments layer
         for i, layer in enumerate(new_webmap.layers):
             if layer["id"] == "Assignments_0":
-                new_webmap.layers[i]["itemId"] = final_item.id
-                new_webmap.layers[i]["url"] = final_item.url + "/0"
+                new_webmap.remove_layer(layer)
+                new_webmap.add_layer(final_item)
+                new_webmap.layers[i]["id"] = "Assignments_0"
                 break
         new_webmap.update()
         

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -422,8 +422,7 @@ def main(args):
                         'bb7d2b495ecc4ea7810b28f16ef71cba': new_webmap.item.id}
         cloned_items = gis.content.clone_items([item], item_mapping=item_mapping, search_existing_items=False)
         if len(cloned_items) == 0:
-            logger.info("Creating dashboard failed")
-            sys.exit(0)
+            raise ValueError("Creating dashboard failed")
             
         # Save new name and share to group
         logger.info("Updating title and sharing to project group")

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -426,8 +426,7 @@ def main(args):
         # Save new name and share to group
         logger.info("Updating title and sharing to project group")
         new_title = project.title + " Dashboard"
-        cloned_items[0].update(item_properties={"title": new_title},
-                               thumbnail="https://www.arcgis.com/apps/opsdashboard/assets/images/no-dashboard-thumb-84c2afc9d73774823c7865b4cc776b9b.png")
+        cloned_items[0].update(item_properties={"title": new_title})
         cloned_items[0].share(groups=[project.group])
         logger.info("Dashboard creation completed")
     logger.info("Script completed")

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -32,13 +32,14 @@ import traceback
 from arcgis.gis import GIS
 from arcgis.apps.workforce.project import Project
 from arcgis.features import FeatureLayerCollection
+from arcgis.mapping import WebMap
 
 
 # Define the set of fields to include for each layer in the joined layer
 
 assignment_type_fields = [
     {
-        "name": "assignment_type_description",
+        "name": "assignmentType",
         "alias": "Assignment Type",
         "source": "description"
     }
@@ -396,7 +397,42 @@ def main(args):
                                     assignment_fields + assignment_type_fields+ worker_fields,
                                     dispatcher_fields)
     logger.info(f"Final Item: {final_item.title}")
-    logger.info("Completed")
+    if args.create_dashboard:
+        if gis.properties["isPortal"]:
+            raise ValueError("GIS needs to be AGOL for the --create-dashboard parameter to work")
+        logger.info("Creating dashboard")
+        
+        # create new webmap
+        map_item = project.dispatcher_webmap.save(
+            item_properties={"title": project.title + " Dashboard Map", "tags": [], "snippet": "Dashboard Map"})
+        new_webmap = WebMap(map_item)
+        
+        # swizzle in joined layer instead of assignments layer
+        for i, layer in enumerate(new_webmap.layers):
+            if layer["id"] == "Assignments_0":
+                new_webmap.layers[i]["itemId"] = final_item.id
+                new_webmap.layers[i]["url"] = final_item.url + "/0"
+                break
+        new_webmap.update()
+        
+        # clone dashboard with your data instead of our data
+        item = gis.content.get("af7cd356c21a4ded87d8cdd452fd8be3")
+        item_mapping = {'377b2b2014f24b0ab9b053d9b2fed113': final_item.id,
+                        'e1904f5c56484163a021155f447adf34': project.workers_item.id,
+                        'bb7d2b495ecc4ea7810b28f16ef71cba': new_webmap.item.id}
+        cloned_items = gis.content.clone_items([item], item_mapping=item_mapping, search_existing_items=False)
+        if len(cloned_items) == 0:
+            logger.info("Creating dashboard failed")
+            sys.exit(0)
+            
+        # Save new name and share to group
+        logger.info("Updating title and sharing to project group")
+        new_title = project.title + " Dashboard"
+        cloned_items[0].update(item_properties={"title": new_title},
+                               thumbnail="https://www.arcgis.com/apps/opsdashboard/assets/images/no-dashboard-thumb-84c2afc9d73774823c7865b4cc776b9b.png")
+        cloned_items[0].share(groups=[project.group])
+        logger.info("Dashboard creation completed")
+    logger.info("Script completed")
 
 
 if __name__ == "__main__":
@@ -406,6 +442,7 @@ if __name__ == "__main__":
     parser.add_argument('-org', dest='org', help="The url of the org/portal to use", required=True)
     parser.add_argument('-project-id', dest='project_id', help="The id of the project to create the view from",
                         required=True)
+    parser.add_argument('--create-dashboard', dest='create_dashboard', action='store_true', help="Create a dashboard using the joined view in AGOL")
     parser.add_argument('-log-file', dest="log_file", help="The file to log to")
     parser.add_argument('--skip-ssl-verification', dest='skip_ssl_verification', action='store_true',
                         help="Verify the SSL Certificate of the server")

--- a/scripts/create_joined_view.py
+++ b/scripts/create_joined_view.py
@@ -398,8 +398,6 @@ def main(args):
                                     dispatcher_fields)
     logger.info(f"Final Item: {final_item.title}")
     if args.create_dashboard:
-        if gis.properties["isPortal"]:
-            raise ValueError("GIS needs to be AGOL for the --create-dashboard parameter to work")
         logger.info("Creating dashboard")
         
         # create new webmap

--- a/scripts/create_ops_dashboard.py
+++ b/scripts/create_ops_dashboard.py
@@ -117,7 +117,7 @@ def main(arguments):
 		new_title = arguments.title
 	else:
 		new_title = project.title + " Dashboard"
-	cloned_items[0].update(item_properties={"title": new_title}, thumbnail="https://www.arcgis.com/apps/opsdashboard/assets/images/no-dashboard-thumb-84c2afc9d73774823c7865b4cc776b9b.png")
+	cloned_items[0].update(item_properties={"title": new_title})
 	cloned_items[0].share(groups=[project.group])
 	logger.info("Completed")
 


### PR DESCRIPTION
Add a `--create-dashboard` optional parameter to use the joined view layer in creation of a dashboard, allowing assignment type names to be shown instead of GUIDs